### PR TITLE
FIX Correctly substitute variable in jq select

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,8 @@ runs:
         FOUND="true"
         # Check there are any tags so we can use jq array selector later
         if [[ $(jq 'map(type)' __response.json) =~ object ]]; then
-          if [[ $(jq '.[] | select(.ref == "refs/tags/$TAG")' __response.json) == "" ]]; then
+          EXISTING_TAG=$(jq ".[] | select(.ref == \"refs/tags/$TAG\")" __response.json)
+          if [[ $EXISTING_TAG == "" ]]; then
             FOUND="false"
           fi
         fi


### PR DESCRIPTION
The `$TAG` variable wasn't being substituted when attempting to find `refs/tags/v1` - it was looking for the string `refs/tags/$TAG` instead.

## After merge:
1. Manually remove the existing `v1` tag
2. Manually create a new `v1` tag at the newest commit
3. Create the 1.0.2 release