### PR TITLE
Fix curl commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
           RESP_CODE=$(curl -w %{http_code} -s -o /dev/null \
           -X DELETE https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ github.token }}"
+          -H "Authorization: token ${{ github.token }}")
           if [[ $RESP_CODE != "204" ]]; then
             echo "Unable to delete release $RELEASE_ID for tag $TAG - HTTP response code was $RESP_CODE"
             exit 1
@@ -98,7 +98,6 @@ runs:
           # Delete tag via GitHub API
           # https://docs.github.com/en/rest/reference/git#delete-a-reference
           RESP_CODE=$(curl -w %{http_code} -s -o /dev/null \
-          curl -s \
           -X DELETE https://api.github.com/repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ github.token }}")


### PR DESCRIPTION
Add missing closing bracket to delete release command.
Remove erroneous second `curl` from delete tag command.

## After merge:
1. Manually remove the existing `v1` tag
2. Manually create a new `v1` tag at the newest commit
3. Create the 1.0.2 release