### PR TITLE
ENH Add input for making pre-release releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Create a tag and an optional release
 ```yml
 steps:
   - name: Create tag and release
-    uses: silverstripe/gha-pull-request@v1
+    uses: silverstripe/gha-tag-release@v1
     with:
       tag: 1.2.3
       release: true
+      delete_existing: true
+      release_description: "Some description about the 1.2.3 release"
+      is_prerelease: false
 ```
-
-Read more information about the inputs available for [silverstripe/gha-pull-request](https://github.com/silverstripe/gha-pull-request).
 
 ## Why there is no SHA input paramater
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     type: boolean
     required: false
     default: false
+  is_prerelease:
+    type: boolean
+    required: false
+    default: false
   release_description:
     type: string
     required: false
@@ -158,7 +162,7 @@ runs:
           "name": "$TAG",
           "body": "$RELEASE_DESCRIPTION",
           "draft": false,
-          "prerelease": false
+          "prerelease": ${{ inputs.is_prerelease }}
         }
         EOF
         )


### PR DESCRIPTION
Needed to allow github actions to create pre-release releases for example after tagging a beta or rc release.

## Parent issue:
- https://github.com/silverstripe/cow/issues/184